### PR TITLE
Add option to disable formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -828,6 +828,11 @@
           "type": "boolean",
           "default": true,
           "description": "If true, parameter declarations are inserted as snippets in function/method call arguments when completing a function/method call"
+        },
+        "cquery.formatting.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "If document formatting is enabled/disabled"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,6 +133,7 @@ function getClientConfig(context: ExtensionContext) {
     ['diagnostics.onType', 'diagnostics.onType'],
     ['codeLens.localVariables', 'codeLens.onLocalVariables'],
     ['emitInactiveRegions', 'misc.showInactiveRegions'],
+    ['formatting.enabled', 'formatting.enabled'],
   ];
   let clientConfig = {
     launchCommand: '',
@@ -142,7 +143,7 @@ function getClientConfig(context: ExtensionContext) {
     },
     workspaceSymbol: {
       sort: false,
-    }
+    },
   };
   let config = workspace.getConfiguration('cquery');
   for (let prop of configMapping) {


### PR DESCRIPTION
Since people may want to use other formatting plugins, add an
option to disable formatting via a middleware intercept.