### PR TITLE
codelens: fix decorations for inline CodeLens

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -266,12 +266,16 @@ export function activate(context: ExtensionContext) {
 
 
     // Inline code lens.
-    let decorationOpts: any = {};
-    decorationOpts.rangeBehavior = DecorationRangeBehavior.ClosedClosed;
-    decorationOpts.color = new ThemeColor('editorCodeLens.foreground');
-    decorationOpts.fontStyle = 'italic';
+    let decorationOpts: DecorationRenderOptions = {
+      after: {
+        fontStyle: 'italic',
+        color: new ThemeColor('editorCodeLens.foreground'),
+      },
+      rangeBehavior: DecorationRangeBehavior.ClosedClosed,
+    };
+
     let codeLensDecoration = window.createTextEditorDecorationType(
-        <DecorationRenderOptions>decorationOpts);
+      decorationOpts);
 
     function displayCodeLens(document: TextDocument, allCodeLens: CodeLens[]) {
       for (let editor of window.visibleTextEditors) {


### PR DESCRIPTION
The decoration options should be applied to the CodeLens text, which comes *after* the range, not the range itself.

before:
![screenshot from 2018-08-15 13-43-36](https://user-images.githubusercontent.com/1916976/44172610-94fbcf00-a092-11e8-972f-c3fc2a551ffb.png)

after (note the italicized font and color):
![screenshot from 2018-08-15 13-48-15](https://user-images.githubusercontent.com/1916976/44172616-9927ec80-a092-11e8-9363-a7833c4cf3ec.png)

