### PR TITLE
Add LD_LIBRARY_PATH to environment

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -249,6 +249,7 @@ export function activate(context: ExtensionContext) {
     let kToForward = [
       'ProgramData',
       'PATH',
+      'LD_LIBRARY_PATH'
     ];
     for (let e of kToForward)
       env[e] = process.env[e];


### PR DESCRIPTION
When launching cquery from the VS Code extension, it uses the wrong
libstdc++.so.6 file, which results into failed dynamic linking. By forwarding
LD_LIBRARY_PATH to the launch env, cquery starts successfully.