### PR TITLE
Add Just My Code support for global symbol search

### DIFF
--- a/package.json
+++ b/package.json
@@ -715,6 +715,15 @@
           "default": null,
           "description": "The maximum number of global search (ie, Ctrl+P + #foo) search results to report. For small search strings on large projects there can be a massive number of results (ie, over 1,000,000) so this limit is important to avoid extremely long delays. null means use the default value provided by the cquery language server."
         },
+        "cquery.misc.workspaceSearchResults": {
+          "type": "string",
+          "enum": [
+            "All",
+            "Just My Code"
+          ],
+          "default": "Just My Code",
+          "description": "The symbols to include in the query results when 'Go to Symbol in Workspace' is invoked"
+        },
         "cquery.misc.indexerCount": {
           "type": "number",
           "default": 0,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,6 +134,7 @@ function getClientConfig(context: ExtensionContext) {
     ['extraClangArguments', 'index.extraClangArguments'],
     ['resourceDirectory', 'misc.resourceDirectory'],
     ['workspaceSymbol.maxNum', 'misc.maxWorkspaceSearchResults'],
+    ['workspaceSymbol.workspaceSearchResults', 'misc.workspaceSearchResults'],
     ['index.threads', 'misc.indexerCount'],
     ['index.enabled', 'misc.enableIndexing'],
     ['enableCacheWrite', 'misc.enableCacheWrite'],
@@ -179,6 +180,11 @@ function getClientConfig(context: ExtensionContext) {
       subconfig[subprops[subprops.length - 1]] = resolveVariables(value);
     }
   }
+
+  // Gather workspaceFolder paths in current workspace.
+  clientConfig["workspaceFolders"] = workspace.workspaceFolders.map(workspaceFolder => {
+    return workspaceFolder.uri.path;
+  });
 
   // Set up a cache directory if there is not one.
   if (!clientConfig.cacheDirectory) {


### PR DESCRIPTION
Inspired from vscode-cpptools `Just My Code` option for workspace symbol request.