### PR TITLE
fix: wiki url

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ code lens, references, code completion, semantic highlighting, and much more.
 
 You currently need to install and build the main cquery server (eventually this
 will be downloaded for you from prebuilts). See the [Getting
-Started](https://github.com/cquery-project/cquery/wiki/Getting-started) wiki
+Started](https://github.com/cquery-project/cquery/wiki) wiki
 entry.
 
 This extension is still in preview. Please see additional documentation at the


### PR DESCRIPTION
[Previous url](https://github.com/cquery-project/cquery/wiki/Getting-started) will open a wiki edit page. `/Getting-started` should be removed.